### PR TITLE
feat: add hint convert modal

### DIFF
--- a/public/locales/en/convert-hint-modal.json
+++ b/public/locales/en/convert-hint-modal.json
@@ -1,0 +1,13 @@
+{
+  "title": "Convert LaTeX Delimiters",
+  "cancel": "Cancel",
+  "confirm": "Confirm",
+  "bracket2dollar": "Bracket to Dollar",
+  "dollar2bracket": "Dollar to Bracket",
+  "bracket": "bracket",
+  "dollar": "dollar",
+  "content": "The LaTeX delimiter in this editor is set to {{delimiterType}}.\nThere are {{count}} instances of {{oppositeDelimiterType}} delimiters in the document.\nDo you want to convert them to {{delimiterType}}?",
+  "conversionDescription": "Delimiter Conversion Description",
+  "currentDelimiter": "Current Delimiter",
+  "newDelimiter": "New Delimiter"
+}

--- a/public/locales/zh-TW/convert-hint-modal.json
+++ b/public/locales/zh-TW/convert-hint-modal.json
@@ -1,0 +1,13 @@
+{
+  "title": "轉換 LaTeX 分隔符號",
+  "cancel": "暫不轉換",
+  "confirm": "確認轉換",
+  "bracket2dollar": "括號轉錢號",
+  "dollar2bracket": "錢號轉括號",
+  "bracket": "括號",
+  "dollar": "錢號",
+  "content": "此編輯器LaTeX分隔符設定為{{delimiterType}}\n文件中包含{{count}}組{{oppositeDelimiterType}}標記\n請問是否轉為{{delimiterType}}？",
+  "conversionDescription": "分隔符轉換示意",
+  "currentDelimiter": "當前分隔符",
+  "newDelimiter": "新分隔符"
+}

--- a/src/components/core/button/toggle-button.js
+++ b/src/components/core/button/toggle-button.js
@@ -1,18 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
-import { useTranslation } from '@/lib/i18n';
 
-
-const ToggleButton = ({ isActive = false, onClick = () => {}, label = '', ariaLabel = '' }) => {
+const ToggleButton = ({ isActive = false, onClick = () => {}, children = '', label = '' }) => {
   return (
     <button
       className={cn('py-2 px-4 rounded-md', isActive ? 'bg-cyan text-white' : 'bg-white text-cyan')}
       onClick={onClick}
-      aria-label={ariaLabel}
+      aria-label={label}
       aria-pressed={isActive}
     >
-      {label}
+      {children}
     </button>
   );
 };
@@ -20,22 +18,22 @@ const ToggleButton = ({ isActive = false, onClick = () => {}, label = '', ariaLa
 ToggleButton.propTypes = {
   isActive: PropTypes.bool,
   onClick: PropTypes.func,
+  children: PropTypes.node,
   label: PropTypes.string,
-  ariaLabel: PropTypes.string,
 };
 
-const ToggleButtonGroup = ({ options = [], activeOption = '', onOptionChange = () => {}, labelPrefix = '' }) => {
-    const t = useTranslation('home');
-    return (
+const ToggleButtonGroup = ({ options = [], activeOption = '', onOptionChange = () => {} }) => {
+  return (
     <>
-      {options.map((option) => (
+      {options.map(({ value, label }) => (
         <ToggleButton
-          key={option}
-          isActive={activeOption === option}
-          onClick={() => onOptionChange(option)}
-          label={t(`${labelPrefix}.${option}`)}
-          ariaLabel={t(`${labelPrefix}.${option}`)}
-        />
+          key={value}
+          isActive={activeOption === value}
+          onClick={() => onOptionChange(value)}
+          label={label}
+        >
+          {label}
+        </ToggleButton>
       ))}
     </>
   );

--- a/src/components/home/convert-hint-modal/index.js
+++ b/src/components/home/convert-hint-modal/index.js
@@ -1,0 +1,107 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import BasicModal from '@/components/core/modal/basic-modal';
+import { useTranslation } from '@/lib/i18n';
+
+const ConvertHintModal = ({
+  isOpen,
+  onClose,
+  displayConfig,
+  setDisplayConfig,
+  laTeXSepConvert,
+  LatexDelimiter,
+  data,
+}) => {
+  const t = useTranslation('convert-hint-modal');
+
+  const countDelimiters = useMemo(() => {
+    const delimiter = displayConfig.latexDelimiter === LatexDelimiter.DOLLAR ? '\\$' : '\\\\(\\\\)';
+    const regex = new RegExp(`${delimiter}.*?${delimiter}`, 'g');
+    const matches = data.match(regex);
+    return matches ? matches.length : 0;
+  }, [data, displayConfig.latexDelimiter, LatexDelimiter]);
+
+  const handleConvert = () => {
+    const newMode =
+      displayConfig.latexDelimiter === LatexDelimiter.DOLLAR
+        ? LatexDelimiter.BRACKET
+        : LatexDelimiter.DOLLAR;
+    setDisplayConfig({ latexDelimiter: newMode });
+    laTeXSepConvert(newMode === LatexDelimiter.DOLLAR ? 'b2d' : 'd2b');
+    onClose();
+  };
+
+  const getConversionText = () =>
+    displayConfig.latexDelimiter === LatexDelimiter.BRACKET
+      ? t('bracket2dollar')
+      : t('dollar2bracket');
+
+  const getDelimiterSymbol = (delimiter) => (delimiter === LatexDelimiter.BRACKET ? '()' : '$');
+
+  const getContentText = () =>
+    t('content', {
+      delimiterType:
+        displayConfig.latexDelimiter === LatexDelimiter.BRACKET ? t('dollar') : t('bracket'),
+      count: countDelimiters,
+      oppositeDelimiterType:
+        displayConfig.latexDelimiter === LatexDelimiter.BRACKET ? t('bracket') : t('dollar'),
+    });
+
+  return (
+    <BasicModal
+      title={t('title')}
+      isOpen={isOpen}
+      hasCancel={true}
+      onClose={onClose}
+      onCancel={onClose}
+      onConfirm={handleConvert}
+      cancelLabel={t('cancel')}
+      confirmLabel={t('confirm')}
+    >
+      <div className="p-4 text-center" id="convert-hint-description">
+        <h2 className="text-xl font-bold mb-4">{getConversionText()}</h2>
+        <div
+          className="flex justify-center items-center mb-4"
+          aria-label={t('conversionDescription')}
+        >
+          <div
+            className="bg-gray-200 p-2 rounded mr-2"
+            aria-label={`${t('currentDelimiter')}: ${displayConfig.latexDelimiter}`}
+          >
+            {getDelimiterSymbol(displayConfig.latexDelimiter)}
+          </div>
+          <span className="text-2xl" aria-hidden="true">
+            →
+          </span>
+          <div
+            className="bg-gray-200 p-2 rounded ml-2"
+            aria-label={`${t('newDelimiter')}: ${
+              displayConfig.latexDelimiter === LatexDelimiter.BRACKET ? t('dollar') : t('bracket')
+            }`}
+          >
+            {getDelimiterSymbol(
+              displayConfig.latexDelimiter === LatexDelimiter.BRACKET
+                ? LatexDelimiter.DOLLAR
+                : LatexDelimiter.BRACKET
+            )}
+          </div>
+        </div>
+        <p className="mb-4" style={{ whiteSpace: 'pre-line' }}>
+          {getContentText()}
+        </p>
+      </div>
+    </BasicModal>
+  );
+};
+
+ConvertHintModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  displayConfig: PropTypes.object.isRequired,
+  setDisplayConfig: PropTypes.func.isRequired,
+  laTeXSepConvert: PropTypes.func.isRequired,
+  LatexDelimiter: PropTypes.object.isRequired,
+  data: PropTypes.string.isRequired,
+};
+
+export default ConvertHintModal;

--- a/src/components/home/convert-hint-modal/index.js
+++ b/src/components/home/convert-hint-modal/index.js
@@ -15,8 +15,11 @@ const ConvertHintModal = ({
   const t = useTranslation('convert-hint-modal');
 
   const countDelimiters = useMemo(() => {
-    const delimiter = displayConfig.latexDelimiter === LatexDelimiter.DOLLAR ? '\\$' : '\\\\(\\\\)';
-    const regex = new RegExp(`${delimiter}.*?${delimiter}`, 'g');
+    const delimiter = displayConfig.latexDelimiter === LatexDelimiter.DOLLAR 
+      ? '\\$.*?\\$'  // Match $...$ format, including empty content
+      : '\\\\\\(.*?\\\\\\)';  // Match \(...\) format, including empty content
+    
+    const regex = new RegExp(delimiter, 'g');
     const matches = data.match(regex);
     return matches ? matches.length : 0;
   }, [data, displayConfig.latexDelimiter, LatexDelimiter]);

--- a/src/components/home/setting-modal/helpers.js
+++ b/src/components/home/setting-modal/helpers.js
@@ -67,7 +67,6 @@ export const useOptionGroup = (t) => {
   }, [t]);
 };
 
-
 export const useDisplayConfig = (initialConfig = asConfigData()) => {
   const [displayConfig, setDisplayConfigState] = useState(initialConfig);
 

--- a/src/components/home/setting-modal/helpers.js
+++ b/src/components/home/setting-modal/helpers.js
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { asConfigData } from '@/lib/config/data';
 
 export const useForm = ({ config, isOpen }) => {
   const [localConfig, setLocalConfig] = useState(config);
@@ -65,20 +64,4 @@ export const useOptionGroup = (t) => {
       },
     ];
   }, [t]);
-};
-
-export const useDisplayConfig = (initialConfig = asConfigData()) => {
-  const [displayConfig, setDisplayConfigState] = useState(initialConfig);
-
-  const setDisplayConfig = useCallback((newConfig) => {
-    setDisplayConfigState((prevConfig) => ({
-      ...prevConfig,
-      ...newConfig,
-    }));
-  }, []);
-
-  return {
-    displayConfig,
-    setDisplayConfig,
-  };
 };

--- a/src/lib/display-config.js
+++ b/src/lib/display-config.js
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react';
+import { asConfigData } from './config/data';
+
+export const ExportType = {
+  ZIP: 'zip',
+  TEXT: 'text',
+};
+
+export const LatexDelimiter = {
+  DOLLAR: 'dollar',
+  BRACKET: 'bracket',
+};
+
+export const DocumentFormat = {
+  BLOCK: 'block',
+  INLINE: 'inline',
+};
+
+export const DocumentColor = {
+  LIGHT: 'light',
+  DARK: 'dark',
+};
+
+export const useDisplayConfig = (initialConfig = asConfigData()) => {
+  const [displayConfig, setDisplayConfigState] = useState(initialConfig);
+
+  const setDisplayConfig = useCallback((newConfig) => {
+    setDisplayConfigState((prevConfig) => ({
+      ...prevConfig,
+      ...newConfig,
+    }));
+  }, []);
+
+  return {
+    displayConfig,
+    setDisplayConfig,
+  };
+};

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -290,7 +290,7 @@ export default function Home() {
           </div>
           <div className="flex justify-end mb-4 mt-4 md:mt-m1">
             <Button variant="primary" className="ml-2" onClick={insertMark}>
-              {t('mark')}
+              {t('mark')} {displayConfig.latexDelimiter === LatexDelimiter.DOLLAR ? '$' : '\\( \\)'}
             </Button>
             <Button
               variant="primary"

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -30,6 +30,7 @@ import Button from '@/components/core/button';
 import { ToggleButtonGroup } from '@/components/core/button/toggle-button';
 import EditIconsTab from '@/components/edit-icons-tab';
 import SettingModal from '@/components/home/setting-modal';
+import ConvertHintModal from '@/components/home/convert-hint-modal';
 import { useDisplayConfig } from '@/components/home/setting-modal/helpers';
 
 const importTextAcceptedExtension = ['.txt', '.md'];
@@ -59,6 +60,7 @@ export default function Home() {
   const t = useTranslation('home');
   const [data, setData] = useState('');
   const [showSettingModal, setShowSettingModal] = useState(false);
+  const [showConvertHintModal, setShowConvertHintModal] = useState(false);
   const [exportType, setExportType] = useState(ExportType.ZIP);
 
   const { displayConfig, setDisplayConfig } = useDisplayConfig();
@@ -311,12 +313,7 @@ export default function Home() {
               className="md:ml-2 ml-1"
               size="sm"
               onClick={() => {
-                const newMode =
-                  displayConfig.latexDelimiter === LatexDelimiter.DOLLAR
-                    ? LatexDelimiter.BRACKET
-                    : LatexDelimiter.DOLLAR;
-                setDisplayConfig({ latexDelimiter: newMode });
-                laTeXSepConvert(newMode === LatexDelimiter.DOLLAR ? 'b2d' : 'd2b');
+                setShowConvertHintModal(true);
               }}
             >
               {displayConfig.latexDelimiter === LatexDelimiter.DOLLAR
@@ -400,6 +397,15 @@ export default function Home() {
           displayConfig={displayConfig}
           exportType={exportType}
           setExportType={setExportType}
+        />
+        <ConvertHintModal
+          isOpen={showConvertHintModal}
+          onClose={() => setShowConvertHintModal(false)}
+          displayConfig={displayConfig}
+          setDisplayConfig={setDisplayConfig}
+          laTeXSepConvert={laTeXSepConvert}
+          LatexDelimiter={LatexDelimiter}
+          data={data}
         />
       </div>
     </div>

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -31,30 +31,10 @@ import { ToggleButtonGroup } from '@/components/core/button/toggle-button';
 import EditIconsTab from '@/components/edit-icons-tab';
 import SettingModal from '@/components/home/setting-modal';
 import ConvertHintModal from '@/components/home/convert-hint-modal';
-import { useDisplayConfig } from '@/components/home/setting-modal/helpers';
+import { useDisplayConfig, ExportType, LatexDelimiter, DocumentFormat, DocumentColor } from '@/lib/display-config';
 
 const importTextAcceptedExtension = ['.txt', '.md'];
 const importAcceptedExtension = [`.${ORIGINAL_FILE_EXTENSION}`];
-
-const ExportType = {
-  ZIP: 'zip',
-  TEXT: 'text',
-};
-
-const LatexDelimiter = {
-  DOLLAR: 'dollar',
-  BRACKET: 'bracket',
-};
-
-const DocumentFormat = {
-  BLOCK: 'block',
-  INLINE: 'inline',
-};
-
-const DocumentColor = {
-  LIGHT: 'light',
-  DARK: 'dark',
-};
 
 export default function Home() {
   const t = useTranslation('home');
@@ -249,6 +229,11 @@ export default function Home() {
     [data, setDisplayConfig]
   );
 
+  const latexDelimiterOptions = [
+    { value: LatexDelimiter.DOLLAR, label: t('latexDelimiter.dollar') },
+    { value: LatexDelimiter.BRACKET, label: t('latexDelimiter.bracket') }
+  ];
+
   return (
     <div className="w-full h-full">
       {/* Top file setting panel */}
@@ -257,10 +242,9 @@ export default function Home() {
           <div className="content-center mr-3">{t('latexDelimiter.name')}</div>
           <div className="bg-white border border-gray-300 rounded-md font-bold p-1">
             <ToggleButtonGroup
-              options={[LatexDelimiter.DOLLAR, LatexDelimiter.BRACKET]}
+              options={latexDelimiterOptions}
               activeOption={displayConfig.latexDelimiter}
               onOptionChange={(option) => setDisplayConfig({ latexDelimiter: option })}
-              labelPrefix="latexDelimiter"
             />
           </div>
         </div>
@@ -344,18 +328,22 @@ export default function Home() {
             <div className="flex justify-end">
               <div className="bg-white border border-gray-300 rounded-md font-bold p-1">
                 <ToggleButtonGroup
-                  options={[DocumentFormat.BLOCK, DocumentFormat.INLINE]}
+                  options={[
+                    { value: DocumentFormat.BLOCK, label: t('documentFormat.block') },
+                    { value: DocumentFormat.INLINE, label: t('documentFormat.inline') }
+                  ]}
                   activeOption={displayConfig.documentFormat}
                   onOptionChange={(option) => setDisplayConfig({ documentFormat: option })}
-                  labelPrefix="documentFormat"
                 />
               </div>
               <div className="bg-white border border-gray-300 rounded-md font-bold p-1 ml-4">
                 <ToggleButtonGroup
-                  options={[DocumentColor.LIGHT, DocumentColor.DARK]}
+                  options={[
+                    { value: DocumentColor.LIGHT, label: t('documentColor.light') },
+                    { value: DocumentColor.DARK, label: t('documentColor.dark') }
+                  ]}
                   activeOption={displayConfig.documentColor}
                   onOptionChange={(option) => setDisplayConfig({ documentColor: option })}
-                  labelPrefix="documentColor"
                 />
               </div>
             </div>


### PR DESCRIPTION
<img width="1470" alt="screenshot for pop-up modal" src="https://github.com/user-attachments/assets/c88077df-4466-40e1-b59e-aae74c2e5e70">

- When the user clicks "Convert," show a pop-up hint modal displaying the current delimiter, the new delimiter, and the amount of the delimiter to be converted.