### PR TITLE
fix: enhance image export functionality by including file type

### DIFF
--- a/src/components/edit-icons-tab.js
+++ b/src/components/edit-icons-tab.js
@@ -32,7 +32,8 @@ const EditIconsTab = ({ insertLatex, addImageToExport }) => {
       latex: `![${altText}](${fileID})`,
       offset: -1
     });
-    addImageToExport(fileID, file);
+    const fileType = file.type.split('/')[1];
+    addImageToExport(fileID, fileType, file);
   }, [insertLatex, addImageToExport]);
 
   return (

--- a/src/lib/import-source.js
+++ b/src/lib/import-source.js
@@ -22,8 +22,9 @@ export async function importSource(text, config = {}, imagesFolder, addImageToEx
       const fileName = relativePath.split('/').pop();
       const blob = await toBlob(file);
       const fileID = fileName.split('.')[0];
+      const fileType = fileName.split('.')[1];
       newImageFiles[fileID] = blob;
-      addImageToExport(fileID, blob);
+      addImageToExport(fileID, fileType, blob);
     }
   }
   setImageFiles(newImageFiles);

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -55,8 +55,8 @@ export default function Home() {
   const importFile = useRef(null);
   const imagesToExportRef = useRef({});
 
-  const addImageToExport = useCallback((fileID, file) => {
-    const fileName = `${fileID}.${file.type.split('/')[1]}`;
+  const addImageToExport = useCallback((fileID, fileType, file) => {
+    const fileName = `${fileID}.${fileType}`;
     imagesToExportRef.current = {
       ...imagesToExportRef.current,
       [fileID]: { file, fileName }


### PR DESCRIPTION
Fix bug by changing how the file type is retrieved, as Blob objects don't support `file.type`.