### PR TITLE
fix: insert heading at the start of the line

### DIFF
--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -162,25 +162,41 @@ export default function Home() {
     importFile.current.click();
   }, []);
 
-  const insertLatex = useCallback(({ latex, offset }) => {
+  const insertLatex = useCallback(({ id, latex, offset }) => {
     const view = codemirrorView.current;
     view.dispatch(
-      view.state.changeByRange((range) => ({
-        changes: [
-          {
-            from: range.from,
-            insert: latex.slice(0, latex.length + offset),
-          },
-          {
-            from: range.to,
-            insert: latex.slice(latex.length + offset, latex.length),
-          },
-        ],
-        range: EditorSelection.range(
-          range.from + latex.length + offset,
-          range.from + latex.length + offset
-        ),
-      }))
+      view.state.changeByRange((range) => {
+        // If it's a heading, insert at the start of the line
+        if (id.startsWith('heading')) {
+          const line = view.state.doc.lineAt(range.from);
+          return {
+            changes: [
+              {
+                from: line.from,
+                insert: latex,
+              },
+            ],
+            range: EditorSelection.range(range.from + latex.length, range.to + latex.length),
+          };
+        }
+
+        return {
+          changes: [
+            {
+              from: range.from,
+              insert: latex.slice(0, latex.length + offset),
+            },
+            {
+              from: range.to,
+              insert: latex.slice(latex.length + offset, latex.length),
+            },
+          ],
+          range: EditorSelection.range(
+            range.from + latex.length + offset,
+            range.from + latex.length + offset
+          ),
+        };
+      })
     );
     view.focus();
   }, []);


### PR DESCRIPTION
### Before

heading 的 insert 會將 `#` insert 到當前游標，而非當前游標開頭行
https://docs.google.com/spreadsheets/d/1V14_lm-o5G5-1xd0FD0L0lxxfSaH43i1Xzx8UEu0wsU/edit?gid=0#gid=0&range=9:9

### After

* 將 heading 的 markdown 符號插入到該行的最前方
* selection 範圍維持跟插入 heading 前一樣的位置
