### PR TITLE
Exclude storybook-static from linting and formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     es2021: true,
     node: true,
   },
+  ignorePatterns: ['storybook-static/**'],
   extends: [
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,4 +8,5 @@ coverage
 public
 .env
 package-lock.json
-yarn.lock 
+yarn.lock
+storybook-static


### PR DESCRIPTION
## Description
Exclude generated Storybook build files from code quality checks to prevent unnecessary linting/formatting of auto-generated content.

- Add storybook-static directory to ESLint ignorePatterns
- Add storybook-static to .prettierignore