### PR TITLE
fix: add missing hash to alert internal link href

### DIFF
--- a/src/components/parser-components/alert/alert.js
+++ b/src/components/parser-components/alert/alert.js
@@ -19,7 +19,7 @@ const Alert = ({ children, internalLinkId = '', variant = '', title = '' }) => {
       </p>
       {children}
       {showBacklink && (
-        <a href={`${internalLinkId}-source`} className={cls('underline', LINK_COLOR)}>
+        <a href={`#${internalLinkId}-source`} className={cls('underline', LINK_COLOR)}>
           返回
         </a>
       )}


### PR DESCRIPTION
### 問題

區塊的返回連結功能失效。


### Steps to Reproduce

在 [a8m](https://access8mathweb.coseeing.org/) 編輯區使用以下語法

```
[閱讀器]<target>

other

> [!NOTE]#target
> Highlights information that users should take into account, even when skimming.
```
### Actual Behavior

區塊的「返回」連結，href 是 `target-source`。

### Expected  Behavior

區塊的「返回」連結，href 應要是 `#target-source`。