### PR TITLE
chore: bump @coseeing/see-mark to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.4",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.0.5",
-        "@coseeing/see-mark": "^1.0.4",
+        "@coseeing/see-mark": "^1.0.5",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.0.18",
         "classnames": "^2.3.2",
@@ -2241,9 +2241,10 @@
       }
     },
     "node_modules/@coseeing/see-mark": {
-      "version": "1.0.4",
-      "resolved": "https://npm.pkg.github.com/download/@coseeing/see-mark/1.0.4/37d724773661e1a0ab714ea341c07fd2c2a0d9e0",
-      "integrity": "sha512-1ye6Q+/G4bQBcDw98/9VmZvMnZC7jCZ1NRkXcuaN1zPZUU/dukWxFLYyvxrGU3eYFHc3Gr2Q6u666qjlToQHRQ==",
+      "version": "1.0.5",
+      "resolved": "https://npm.pkg.github.com/download/@coseeing/see-mark/1.0.5/05fd35a80ae519a20c17292a6ec2097de1f5bf1f",
+      "integrity": "sha512-+VM3zfLZx/K53Ncjz4w7c4Ptkq9exWxBYXFMTPOySbUP9cSIwEPEmeHJKYGboESgseRBRPF1SmI5KJbeDzKTvA==",
+      "license": "ISC",
       "dependencies": {
         "html-react-parser": "^5.2.5",
         "marked": "^15.0.11",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "main.js",
   "dependencies": {
     "@codemirror/lang-markdown": "^6.0.5",
-    "@coseeing/see-mark": "^1.0.4",
+    "@coseeing/see-mark": "^1.0.5",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "classnames": "^2.3.2",


### PR DESCRIPTION
Bump @coseeing/see-mark to latest to include:
* https://github.com/coseeing/SeeMark/pull/13
* https://github.com/coseeing/SeeMark/pull/14
* https://github.com/coseeing/SeeMark/pull/9 (not used in a8m)

