### PR TITLE
feat: update external link UI for v2 design

### DIFF
--- a/src/components/parser-components/external-link/external-link.js
+++ b/src/components/parser-components/external-link/external-link.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { IconExternalLink } from '@tabler/icons-react';
+
+import Tooltip from '@/components/core/tooltip';
+
+const linkClassName =
+  'inline-flex items-center gap-1 px-2 py-1 rounded text-primary underline hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
+
+const ExternalLink = ({ display = '', target = '', title = '', newTab = false }) => {
+  const anchor = (
+    <a
+      href={target}
+      {...(newTab && { target: '_blank', rel: 'noopener noreferrer' })}
+      className={linkClassName}
+    >
+      {display}
+      {newTab && <IconExternalLink size={20} aria-hidden="true" />}
+    </a>
+  );
+  return title ? <Tooltip label={title}>{anchor}</Tooltip> : anchor;
+};
+
+ExternalLink.propTypes = {
+  display: PropTypes.string,
+  target: PropTypes.string,
+  title: PropTypes.string,
+  newTab: PropTypes.bool,
+};
+
+export const ExternalLinkTab = (props) => <ExternalLink {...props} newTab />;
+
+export const ExternalLinkTitle = (props) => <ExternalLink {...props} />;
+
+export const ExternalLinkTabTitle = (props) => <ExternalLink {...props} newTab />;

--- a/src/index.css
+++ b/src/index.css
@@ -52,8 +52,9 @@ math {
 .right-side-preview-area ol,
 .right-side-preview-area ul,
 .right-side-preview-area menu,
-.right-side-preview-area svg:not(.octicon) {
-  all: revert; /* reset Tailwind override to browser default */
+.right-side-preview-area svg:not(.octicon):not(.tabler-icon) {
+  all: revert;
+  /* reset Tailwind override to browser default */
 }
 
 .right-side-preview-area ul,
@@ -95,4 +96,8 @@ math {
 .right-side-preview-area.darkmode h5,
 .right-side-preview-area.darkmode h6 {
   color: white;
+}
+
+.right-side-preview-area a:not([class]) {
+  @apply inline-flex items-center gap-1 px-2 py-1 rounded text-primary underline hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary;
 }

--- a/src/pages/home/useSeeMarkParse.js
+++ b/src/pages/home/useSeeMarkParse.js
@@ -3,6 +3,11 @@ import { useCallback } from 'react';
 import { createMarkdownToReactParser } from '@coseeing/see-mark';
 
 import Alert from '@/components/parser-components/alert/alert';
+import {
+  ExternalLinkTab,
+  ExternalLinkTabTitle,
+  ExternalLinkTitle,
+} from '@/components/parser-components/external-link/external-link';
 import InternalLink from '@/components/parser-components/internal-link/internal-link';
 
 const useSeeMarkParse = ({ latexDelimiter, documentFormat, imageFiles }) => {
@@ -15,7 +20,13 @@ const useSeeMarkParse = ({ latexDelimiter, documentFormat, imageFiles }) => {
           imageFiles,
           shouldBuildImageObjectURL: true,
         },
-        components: { alert: Alert, internalLink: InternalLink },
+        components: {
+          alert: Alert,
+          internalLink: InternalLink,
+          externalLinkTab: ExternalLinkTab,
+          externalLinkTitle: ExternalLinkTitle,
+          externalLinkTabTitle: ExternalLinkTabTitle,
+        },
       })(markdown);
     },
     [imageFiles, latexDelimiter, documentFormat]


### PR DESCRIPTION
Solve #118 

當左欄使用以下語法時
```
[a11y 新手村](https://a11yvillage.coseeing.org/zh-TW)
@[a11y 新手村（另開新頁）](https://a11yvillage.coseeing.org/zh-TW)
[a11y 新手村][[a11y 新手村]](https://a11yvillage.coseeing.org/zh-TW)
@[a11y 新手村（另開新頁）][[a11y 新手村]](https://a11yvillage.coseeing.org/zh-TW)
```

更新右欄 preview 區域裡連結的UI符合[Figma設計稿](https://www.figma.com/design/7gvWa3UzE4w5Kloy2CYGTb/%E5%B7%A5%E5%85%B7%E9%A1%9E%E8%A8%AD%E8%A8%88%E7%B3%BB%E7%B5%B1_2025?node-id=906-2935&t=VYpkpCFtXhBxbcPV-0)樣式。

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExanR2YTQwYWFnMG56ODhqcjF6YWV4emFqdHdzZmJxbWl1YXUzdDZhaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/8lqsQaK86BLcnw7sdE/giphy.gif)



