### PR TITLE
feat: add insert iframe modal

### DIFF
--- a/public/locales/en/iframe-input-modal.json
+++ b/public/locales/en/iframe-input-modal.json
@@ -1,0 +1,12 @@
+{
+  "title": "Embed Iframe",
+  "titleLabel": "Iframe Title",
+  "titlePlaceholder": "Enter Iframe title",
+  "titleRequiredError": "Iframe title is required",
+  "urlLabel": "Source",
+  "urlPlaceholder": "Enter source URL",
+  "urlRequiredError": "Source is required",
+  "urlInvalidError": "Please enter a valid URL (e.g. https://example.com)",
+  "cancel": "Cancel",
+  "confirm": "Confirm"
+}

--- a/public/locales/en/tabs.json
+++ b/public/locales/en/tabs.json
@@ -16,6 +16,7 @@
     "heading6": "heading6",
     "horizontal_rule": "horizontal_rule",
     "insert_image": "insert_image",
+    "insert_iframe": "insert_iframe",
     "italic": "italic",
     "numbered_list": "numbered_list",
     "quote": "quote",

--- a/public/locales/zh-TW/iframe-input-modal.json
+++ b/public/locales/zh-TW/iframe-input-modal.json
@@ -1,0 +1,12 @@
+{
+  "title": "嵌入 Iframe",
+  "titleLabel": "Iframe 標題",
+  "titlePlaceholder": "請輸入 Iframe 標題",
+  "titleRequiredError": "Iframe 標題為必填",
+  "urlLabel": "來源網址",
+  "urlPlaceholder": "請輸入來源網址",
+  "urlRequiredError": "來源網址為必填",
+  "urlInvalidError": "請輸入有效的網址（例如：https://example.com）",
+  "cancel": "取消",
+  "confirm": "確認"
+}

--- a/public/locales/zh-TW/tabs.json
+++ b/public/locales/zh-TW/tabs.json
@@ -15,6 +15,7 @@
     "heading6": "標題6",
     "horizontal_rule": "分隔線",
     "insert_image": "插入圖片",
+    "insert_iframe": "插入外部媒體",
     "italic": "斜體",
     "numbered_list": "編號清單",
     "quote": "引用",

--- a/public/locales/zh-TW/tabs.json
+++ b/public/locales/zh-TW/tabs.json
@@ -15,7 +15,7 @@
     "heading6": "標題6",
     "horizontal_rule": "分隔線",
     "insert_image": "插入圖片",
-    "insert_iframe": "插入外部媒體",
+    "insert_iframe": "插入iframe",
     "italic": "斜體",
     "numbered_list": "編號清單",
     "quote": "引用",

--- a/src/components/edit-icons-tab.js
+++ b/src/components/edit-icons-tab.js
@@ -10,6 +10,7 @@ import { compare } from '@/lib/data-process';
 import mathTabList from '@/lib/tabs/math';
 import ImageUploadModal from './image-upload-modal';
 import LinkInputModal from './link-input-modal';
+import IframeInputModal from './iframe-input-modal';
 import Tooltip from './core/tooltip';
 
 const generateUniqueId = (length = 8) => {
@@ -24,6 +25,7 @@ const EditIconsTab = ({ insertLatex, addImageToExport }) => {
   const [selectedMathTabIndex, setSelectedMathTabIndex] = useState(0);
   const [isImageModalOpen, setIsImageModalOpen] = useState(false);
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
+  const [isIframeModalOpen, setIsIframeModalOpen] = useState(false);
 
   const t = useTranslation('tabs');
 
@@ -32,6 +34,17 @@ const EditIconsTab = ({ insertLatex, addImageToExport }) => {
       insertLatex({
         id: 'create_link',
         latex: markdown,
+        offset: 0,
+      });
+    },
+    [insertLatex]
+  );
+
+  const handleIframeConfirm = useCallback(
+    (title, url) => {
+      insertLatex({
+        id: 'insert_iframe',
+        latex: `@![${title}](${url})`,
         offset: 0,
       });
     },
@@ -146,6 +159,10 @@ const EditIconsTab = ({ insertLatex, addImageToExport }) => {
                       setIsLinkModalOpen(true);
                       return;
                     }
+                    if (tab.id === 'insert_iframe') {
+                      setIsIframeModalOpen(true);
+                      return;
+                    }
                     insertLatex(tab);
                   }}
                 >
@@ -165,6 +182,11 @@ const EditIconsTab = ({ insertLatex, addImageToExport }) => {
         isOpen={isLinkModalOpen}
         onClose={() => setIsLinkModalOpen(false)}
         onConfirm={handleLinkConfirm}
+      />
+      <IframeInputModal
+        isOpen={isIframeModalOpen}
+        onClose={() => setIsIframeModalOpen(false)}
+        onConfirm={handleIframeConfirm}
       />
     </>
   );

--- a/src/components/iframe-input-modal.js
+++ b/src/components/iframe-input-modal.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from '@/lib/i18n';
+import { isValidUrl } from '@/lib/url';
+import BasicModal from '@/components/core/modal/basic-modal';
+import TextInput from '@/components/core/text-input';
+
+const IframeInputModal = ({ isOpen, onClose, onConfirm }) => {
+  const [title, setTitle] = useState('');
+  const [url, setUrl] = useState('');
+  const [titleError, setTitleError] = useState('');
+  const [urlError, setUrlError] = useState('');
+  const t = useTranslation('iframe-input-modal');
+
+  const resetForm = () => {
+    setTitle('');
+    setUrl('');
+    setTitleError('');
+    setUrlError('');
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    const isTitleEmpty = !title.trim();
+    const isUrlEmpty = !url.trim();
+    const isUrlInvalid = !isUrlEmpty && !isValidUrl(url);
+
+    if (isTitleEmpty) setTitleError(t('titleRequiredError'));
+    if (isUrlEmpty) setUrlError(t('urlRequiredError'));
+    else if (isUrlInvalid) setUrlError(t('urlInvalidError'));
+    if (isTitleEmpty || isUrlEmpty || isUrlInvalid) return;
+
+    onConfirm(title.trim(), url.trim());
+    handleClose();
+  };
+
+  return (
+    <BasicModal
+      title={t('title')}
+      isOpen={isOpen}
+      onClose={handleClose}
+      onCancel={handleClose}
+      onConfirm={handleConfirm}
+      cancelLabel={t('cancel')}
+      confirmLabel={t('confirm')}
+    >
+      <div className="flex flex-col gap-6">
+        <TextInput
+          id="iframe-title"
+          label={t('titleLabel')}
+          value={title}
+          onChange={(val) => {
+            setTitle(val);
+            setTitleError('');
+          }}
+          placeholder={t('titlePlaceholder')}
+          error={titleError}
+          required
+        />
+
+        <TextInput
+          id="iframe-url"
+          type="url"
+          label={t('urlLabel')}
+          value={url}
+          onChange={(val) => {
+            setUrl(val);
+            setUrlError('');
+          }}
+          placeholder={t('urlPlaceholder')}
+          error={urlError}
+          required
+        />
+      </div>
+    </BasicModal>
+  );
+};
+
+IframeInputModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+};
+
+export default IframeInputModal;

--- a/src/components/link-input-modal.js
+++ b/src/components/link-input-modal.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from '@/lib/i18n';
+import { isValidUrl } from '@/lib/url';
 import BasicModal from '@/components/core/modal/basic-modal';
 import TextInput from '@/components/core/text-input';
 import RadioGroup from '@/components/core/radio-group';
@@ -26,15 +27,6 @@ const LinkInputModal = ({ isOpen, onClose, onConfirm }) => {
   const handleClose = () => {
     resetForm();
     onClose();
-  };
-
-  const isValidUrl = (value) => {
-    try {
-      const parsed = new URL(value.trim());
-      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-    } catch {
-      return false;
-    }
   };
 
   const handleConfirm = () => {

--- a/src/components/svg/markdown/insert_iframe.svg
+++ b/src/components/svg/markdown/insert_iframe.svg
@@ -1,0 +1,4 @@
+<svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="14" y="15" width="24" height="22" rx="1.5" stroke="#454545" stroke-width="1.5"/>
+<text x="26" y="27.5" text-anchor="middle" dominant-baseline="middle" font-size="11" font-weight="700" fill="#454545" font-family="Arial, Helvetica, sans-serif">@!</text>
+</svg>

--- a/src/lib/tabs/markdowns.js
+++ b/src/lib/tabs/markdowns.js
@@ -13,6 +13,7 @@ import { ReactComponent as CreateLink } from '@/components/svg/markdown/create_l
 import { ReactComponent as InsertImage } from '@/components/svg/markdown/insert_image.svg';
 import { ReactComponent as Quote } from '@/components/svg/markdown/quote.svg';
 import { ReactComponent as Table } from '@/components/svg/markdown/table.svg';
+import { ReactComponent as InsertIframe } from '@/components/svg/markdown/insert_iframe.svg';
 
 const markdowns = [
   {
@@ -118,6 +119,14 @@ const markdowns = [
     category: 'markdown',
     shortcut: -1,
     Icon: InsertImage,
+  },
+  {
+    id: 'insert_iframe',
+    latex: '@![]()',
+    offset: -3,
+    category: 'markdown',
+    shortcut: -1,
+    Icon: InsertIframe,
   },
   {
     id: 'quote',

--- a/src/lib/url.js
+++ b/src/lib/url.js
@@ -1,0 +1,8 @@
+export const isValidUrl = (value) => {
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
Solves https://github.com/coseeing/Access8MathWeb/issues/114 .

## Summary

  - Adds IframeInputModal — a modal with title and URL fields that inserts an iframe markdown block into the editor
  - Extracts isValidUrl from LinkInputModal into src/lib/url.js so both modals share the same validation logic
  - Adds the iframe markdown button and markdown syntax insertion support

## Demo

<img width="1860" height="926" alt="Screenshot 2026-04-24 at 20 39 13" src="https://github.com/user-attachments/assets/3fc9ce45-c99a-401b-957c-3b2811cb86cb" />

## Note

1. Why there is no preview panel

The [design](https://www.figma.com/design/7gvWa3UzE4w5Kloy2CYGTb/%E5%B7%A5%E5%85%B7%E9%A1%9E%E8%A8%AD%E8%A8%88%E7%B3%BB%E7%B5%B1_2025?node-id=615-5142&t=I5GtN9tuezzPDshx-0) includes an iframe preview panel inside the modal. I currently remove it because iframe load/error state is not reliably detectable in the browser:

  - The onerror event does not fire for the most common failure cases — blocked by X-Frame-Options or Content-Security-Policy: frame-ancestors headers (which most sites
   send)
  - The load event fires regardless of whether the content loaded successfully or was blocked
  - Cross-origin content prevents any inspection of contentDocument after load

We can discuss if the feature is necessary in future meetings.

2. insert_iframe button svg：設計師還沒確認用哪個 icon，我先暫時先放一個，之後等拿到 svg 檔案再更新