### PR TITLE
feat: update Image, ImageLink, ImageDisplay and ImageDisplayLink UI for v2 design

### DIFF
--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -5,18 +5,16 @@ import { IconExternalLink } from '@tabler/icons-react';
 import Tooltip from '@/components/core/tooltip';
 
 const Image = ({ alt = '', source = '', display = '', target = '' }) => {
-  const img = <img src={source} alt={alt} className="block w-full" />;
+  const imgEl = <img src={source} alt={alt} className="block w-full" />;
 
-  const imgWithTooltip = alt ? <Tooltip label={alt}>{img}</Tooltip> : img;
-
-  const imgWithLink = target ? (
+  const trigger = target ? (
     <a
       href={target}
       target="_blank"
       rel="noopener noreferrer"
       className="relative block"
     >
-      {imgWithTooltip}
+      {imgEl}
       <span
         aria-hidden="true"
         className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
@@ -25,14 +23,24 @@ const Image = ({ alt = '', source = '', display = '', target = '' }) => {
       </span>
     </a>
   ) : (
-    <span className="block">{imgWithTooltip}</span>
+    imgEl
   );
 
-  if (!display) return imgWithLink;
+  const tooltipped = alt ? (
+    <span className="block overflow-hidden">
+      <Tooltip label={alt}>
+        <span className="block -mt-[15px] pt-[15px]">{trigger}</span>
+      </Tooltip>
+    </span>
+  ) : (
+    trigger
+  );
+
+  if (!display) return tooltipped;
 
   return (
     <figure>
-      {imgWithLink}
+      {tooltipped}
       <figcaption className="mt-3 text-center text-base text-text-secondary">
         {display}
       </figcaption>

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -12,13 +12,19 @@ const useImageBroken = (source) => {
   };
 };
 
-const renderImg = (source, alt, onError) => (
+const Img = ({ source = '', alt = '', onError }) => (
   <img src={source} alt={alt} className="block w-full" onError={onError} />
 );
 
-const LinkedImage = ({ source = '', alt = '', target = '', broken = false, onError }) => (
+Img.propTypes = {
+  source: PropTypes.string,
+  alt: PropTypes.string,
+  onError: PropTypes.func,
+};
+
+const LinkedImg = ({ source = '', alt = '', target = '', broken = false, onError }) => (
   <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
-    <img src={source} alt={alt} className="block w-full" onError={onError} />
+    <Img source={source} alt={alt} onError={onError} />
     {!broken && (
       <span
         aria-hidden="true"
@@ -30,7 +36,7 @@ const LinkedImage = ({ source = '', alt = '', target = '', broken = false, onErr
   </a>
 );
 
-LinkedImage.propTypes = {
+LinkedImg.propTypes = {
   source: PropTypes.string,
   alt: PropTypes.string,
   target: PropTypes.string,
@@ -38,27 +44,42 @@ LinkedImage.propTypes = {
   onError: PropTypes.func,
 };
 
-const withAltTooltip = (content, alt, broken) =>
-  alt && !broken ? (
+const AltTooltip = ({ alt = '', disabled = false, children }) => {
+  if (!alt || disabled) return children;
+  return (
     <span className="block overflow-hidden">
       <Tooltip label={alt}>
-        <span className="block -mt-[15px] pt-[15px]">{content}</span>
+        <span className="block -mt-[15px] pt-[15px]">{children}</span>
       </Tooltip>
     </span>
-  ) : (
-    content
   );
+};
 
-const withDisplayCaption = (content, display) => (
+AltTooltip.propTypes = {
+  alt: PropTypes.string,
+  disabled: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+};
+
+const Caption = ({ display = '', children }) => (
   <figure>
-    {content}
+    {children}
     <figcaption className="mt-3 text-center text-base text-text-secondary">{display}</figcaption>
   </figure>
 );
 
+Caption.propTypes = {
+  display: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
 const Image = ({ alt = '', source = '' }) => {
   const { broken, onError } = useImageBroken(source);
-  return withAltTooltip(renderImg(source, alt, onError), alt, broken);
+  return (
+    <AltTooltip alt={alt} disabled={broken}>
+      <Img source={source} alt={alt} onError={onError} />
+    </AltTooltip>
+  );
 };
 
 Image.propTypes = {
@@ -68,10 +89,10 @@ Image.propTypes = {
 
 export const ImageLink = ({ alt = '', source = '', target = '' }) => {
   const { broken, onError } = useImageBroken(source);
-  return withAltTooltip(
-    <LinkedImage source={source} alt={alt} target={target} broken={broken} onError={onError} />,
-    alt,
-    broken
+  return (
+    <AltTooltip alt={alt} disabled={broken}>
+      <LinkedImg source={source} alt={alt} target={target} broken={broken} onError={onError} />
+    </AltTooltip>
   );
 };
 
@@ -83,7 +104,13 @@ ImageLink.propTypes = {
 
 export const ImageDisplay = ({ alt = '', display = '', source = '' }) => {
   const { broken, onError } = useImageBroken(source);
-  return withDisplayCaption(withAltTooltip(renderImg(source, alt, onError), alt, broken), display);
+  return (
+    <Caption display={display}>
+      <AltTooltip alt={alt} disabled={broken}>
+        <Img source={source} alt={alt} onError={onError} />
+      </AltTooltip>
+    </Caption>
+  );
 };
 
 ImageDisplay.propTypes = {
@@ -94,13 +121,12 @@ ImageDisplay.propTypes = {
 
 export const ImageDisplayLink = ({ alt = '', display = '', source = '', target = '' }) => {
   const { broken, onError } = useImageBroken(source);
-  return withDisplayCaption(
-    withAltTooltip(
-      <LinkedImage source={source} alt={alt} target={target} broken={broken} onError={onError} />,
-      alt,
-      broken
-    ),
-    display
+  return (
+    <Caption display={display}>
+      <AltTooltip alt={alt} disabled={broken}>
+        <LinkedImg source={source} alt={alt} target={target} broken={broken} onError={onError} />
+      </AltTooltip>
+    </Caption>
   );
 };
 

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -8,12 +8,7 @@ const Image = ({ alt = '', source = '', display = '', target = '' }) => {
   const imgEl = <img src={source} alt={alt} className="block w-full" />;
 
   const trigger = target ? (
-    <a
-      href={target}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="relative block"
-    >
+    <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
       {imgEl}
       <span
         aria-hidden="true"
@@ -41,9 +36,7 @@ const Image = ({ alt = '', source = '', display = '', target = '' }) => {
   return (
     <figure>
       {tooltipped}
-      <figcaption className="mt-3 text-center text-base text-text-secondary">
-        {display}
-      </figcaption>
+      <figcaption className="mt-3 text-center text-base text-text-secondary">{display}</figcaption>
     </figure>
   );
 };

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { IconExternalLink } from '@tabler/icons-react';
 
@@ -6,17 +6,35 @@ import Tooltip from '@/components/core/tooltip';
 
 const renderImg = (source, alt) => <img src={source} alt={alt} className="block w-full" />;
 
-const renderLinkedImg = (source, alt, target) => (
-  <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
-    {renderImg(source, alt)}
-    <span
-      aria-hidden="true"
-      className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
-    >
-      <IconExternalLink size={20} />
-    </span>
-  </a>
-);
+const LinkedImage = ({ source = '', alt = '', target = '' }) => {
+  const [erroredSource, setErroredSource] = useState(null);
+  const imageBroken = erroredSource === source;
+
+  return (
+    <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
+      <img
+        src={source}
+        alt={alt}
+        className="block w-full"
+        onError={() => setErroredSource(source)}
+      />
+      {!imageBroken && (
+        <span
+          aria-hidden="true"
+          className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
+        >
+          <IconExternalLink size={20} />
+        </span>
+      )}
+    </a>
+  );
+};
+
+LinkedImage.propTypes = {
+  source: PropTypes.string,
+  alt: PropTypes.string,
+  target: PropTypes.string,
+};
 
 const withAltTooltip = (content, alt) =>
   alt ? (
@@ -44,7 +62,7 @@ Image.propTypes = {
 };
 
 export const ImageLink = ({ alt = '', source = '', target = '' }) =>
-  withAltTooltip(renderLinkedImg(source, alt, target), alt);
+  withAltTooltip(<LinkedImage source={source} alt={alt} target={target} />, alt);
 
 ImageLink.propTypes = {
   alt: PropTypes.string,
@@ -62,7 +80,10 @@ ImageDisplay.propTypes = {
 };
 
 export const ImageDisplayLink = ({ alt = '', display = '', source = '', target = '' }) =>
-  withDisplayCaption(withAltTooltip(renderLinkedImg(source, alt, target), alt), display);
+  withDisplayCaption(
+    withAltTooltip(<LinkedImage source={source} alt={alt} target={target} />, alt),
+    display
+  );
 
 ImageDisplayLink.propTypes = {
   alt: PropTypes.string,

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -4,54 +4,71 @@ import { IconExternalLink } from '@tabler/icons-react';
 
 import Tooltip from '@/components/core/tooltip';
 
-const Image = ({ alt = '', source = '', display = '', target = '' }) => {
-  const imgEl = <img src={source} alt={alt} className="block w-full" />;
+const renderImg = (source, alt) => <img src={source} alt={alt} className="block w-full" />;
 
-  const trigger = target ? (
-    <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
-      {imgEl}
-      <span
-        aria-hidden="true"
-        className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
-      >
-        <IconExternalLink size={20} />
-      </span>
-    </a>
-  ) : (
-    imgEl
-  );
+const renderLinkedImg = (source, alt, target) => (
+  <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
+    {renderImg(source, alt)}
+    <span
+      aria-hidden="true"
+      className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
+    >
+      <IconExternalLink size={20} />
+    </span>
+  </a>
+);
 
-  const tooltipped = alt ? (
+const withAltTooltip = (content, alt) =>
+  alt ? (
     <span className="block overflow-hidden">
       <Tooltip label={alt}>
-        <span className="block -mt-[15px] pt-[15px]">{trigger}</span>
+        <span className="block -mt-[15px] pt-[15px]">{content}</span>
       </Tooltip>
     </span>
   ) : (
-    trigger
+    content
   );
 
-  if (!display) return tooltipped;
+const withDisplayCaption = (content, display) => (
+  <figure>
+    {content}
+    <figcaption className="mt-3 text-center text-base text-text-secondary">{display}</figcaption>
+  </figure>
+);
 
-  return (
-    <figure>
-      {tooltipped}
-      <figcaption className="mt-3 text-center text-base text-text-secondary">{display}</figcaption>
-    </figure>
-  );
-};
+const Image = ({ alt = '', source = '' }) => withAltTooltip(renderImg(source, alt), alt);
 
 Image.propTypes = {
   alt: PropTypes.string,
   source: PropTypes.string,
-  display: PropTypes.string,
+};
+
+export const ImageLink = ({ alt = '', source = '', target = '' }) =>
+  withAltTooltip(renderLinkedImg(source, alt, target), alt);
+
+ImageLink.propTypes = {
+  alt: PropTypes.string,
+  source: PropTypes.string,
   target: PropTypes.string,
 };
 
-export const ImageLink = (props) => <Image {...props} />;
+export const ImageDisplay = ({ alt = '', display = '', source = '' }) =>
+  withDisplayCaption(withAltTooltip(renderImg(source, alt), alt), display);
 
-export const ImageDisplay = (props) => <Image {...props} />;
+ImageDisplay.propTypes = {
+  alt: PropTypes.string,
+  display: PropTypes.string,
+  source: PropTypes.string,
+};
 
-export const ImageDisplayLink = (props) => <Image {...props} />;
+export const ImageDisplayLink = ({ alt = '', display = '', source = '', target = '' }) =>
+  withDisplayCaption(withAltTooltip(renderLinkedImg(source, alt, target), alt), display);
+
+ImageDisplayLink.propTypes = {
+  alt: PropTypes.string,
+  display: PropTypes.string,
+  source: PropTypes.string,
+  target: PropTypes.string,
+};
 
 export default Image;

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -4,40 +4,42 @@ import { IconExternalLink } from '@tabler/icons-react';
 
 import Tooltip from '@/components/core/tooltip';
 
-const renderImg = (source, alt) => <img src={source} alt={alt} className="block w-full" />;
-
-const LinkedImage = ({ source = '', alt = '', target = '' }) => {
+const useImageBroken = (source) => {
   const [erroredSource, setErroredSource] = useState(null);
-  const imageBroken = erroredSource === source;
-
-  return (
-    <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
-      <img
-        src={source}
-        alt={alt}
-        className="block w-full"
-        onError={() => setErroredSource(source)}
-      />
-      {!imageBroken && (
-        <span
-          aria-hidden="true"
-          className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
-        >
-          <IconExternalLink size={20} />
-        </span>
-      )}
-    </a>
-  );
+  return {
+    broken: erroredSource === source,
+    onError: () => setErroredSource(source),
+  };
 };
+
+const renderImg = (source, alt, onError) => (
+  <img src={source} alt={alt} className="block w-full" onError={onError} />
+);
+
+const LinkedImage = ({ source = '', alt = '', target = '', broken = false, onError }) => (
+  <a href={target} target="_blank" rel="noopener noreferrer" className="relative block">
+    <img src={source} alt={alt} className="block w-full" onError={onError} />
+    {!broken && (
+      <span
+        aria-hidden="true"
+        className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
+      >
+        <IconExternalLink size={20} />
+      </span>
+    )}
+  </a>
+);
 
 LinkedImage.propTypes = {
   source: PropTypes.string,
   alt: PropTypes.string,
   target: PropTypes.string,
+  broken: PropTypes.bool,
+  onError: PropTypes.func,
 };
 
-const withAltTooltip = (content, alt) =>
-  alt ? (
+const withAltTooltip = (content, alt, broken) =>
+  alt && !broken ? (
     <span className="block overflow-hidden">
       <Tooltip label={alt}>
         <span className="block -mt-[15px] pt-[15px]">{content}</span>
@@ -54,15 +56,24 @@ const withDisplayCaption = (content, display) => (
   </figure>
 );
 
-const Image = ({ alt = '', source = '' }) => withAltTooltip(renderImg(source, alt), alt);
+const Image = ({ alt = '', source = '' }) => {
+  const { broken, onError } = useImageBroken(source);
+  return withAltTooltip(renderImg(source, alt, onError), alt, broken);
+};
 
 Image.propTypes = {
   alt: PropTypes.string,
   source: PropTypes.string,
 };
 
-export const ImageLink = ({ alt = '', source = '', target = '' }) =>
-  withAltTooltip(<LinkedImage source={source} alt={alt} target={target} />, alt);
+export const ImageLink = ({ alt = '', source = '', target = '' }) => {
+  const { broken, onError } = useImageBroken(source);
+  return withAltTooltip(
+    <LinkedImage source={source} alt={alt} target={target} broken={broken} onError={onError} />,
+    alt,
+    broken
+  );
+};
 
 ImageLink.propTypes = {
   alt: PropTypes.string,
@@ -70,8 +81,10 @@ ImageLink.propTypes = {
   target: PropTypes.string,
 };
 
-export const ImageDisplay = ({ alt = '', display = '', source = '' }) =>
-  withDisplayCaption(withAltTooltip(renderImg(source, alt), alt), display);
+export const ImageDisplay = ({ alt = '', display = '', source = '' }) => {
+  const { broken, onError } = useImageBroken(source);
+  return withDisplayCaption(withAltTooltip(renderImg(source, alt, onError), alt, broken), display);
+};
 
 ImageDisplay.propTypes = {
   alt: PropTypes.string,
@@ -79,11 +92,17 @@ ImageDisplay.propTypes = {
   source: PropTypes.string,
 };
 
-export const ImageDisplayLink = ({ alt = '', display = '', source = '', target = '' }) =>
-  withDisplayCaption(
-    withAltTooltip(<LinkedImage source={source} alt={alt} target={target} />, alt),
+export const ImageDisplayLink = ({ alt = '', display = '', source = '', target = '' }) => {
+  const { broken, onError } = useImageBroken(source);
+  return withDisplayCaption(
+    withAltTooltip(
+      <LinkedImage source={source} alt={alt} target={target} broken={broken} onError={onError} />,
+      alt,
+      broken
+    ),
     display
   );
+};
 
 ImageDisplayLink.propTypes = {
   alt: PropTypes.string,

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -25,7 +25,7 @@ const Image = ({ alt = '', source = '', display = '', target = '' }) => {
       </span>
     </a>
   ) : (
-    imgWithTooltip
+    <span className="block">{imgWithTooltip}</span>
   );
 
   if (!display) return imgWithLink;

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -33,7 +33,9 @@ const Image = ({ alt = '', source = '', display = '', target = '' }) => {
   return (
     <figure>
       {imgWithLink}
-      <figcaption className="mt-2 text-center text-text-primary">{display}</figcaption>
+      <figcaption className="mt-3 text-center text-base text-text-secondary">
+        {display}
+      </figcaption>
     </figure>
   );
 };

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { IconExternalLink } from '@tabler/icons-react';
+
+import Tooltip from '@/components/core/tooltip';
+
+const Image = ({ alt = '', source = '', display = '', target = '' }) => {
+  const img = <img src={source} alt={alt} className="block w-full" />;
+
+  const imgWithTooltip = alt ? <Tooltip label={alt}>{img}</Tooltip> : img;
+
+  const imgWithLink = target ? (
+    <a
+      href={target}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="relative block"
+    >
+      {imgWithTooltip}
+      <span
+        aria-hidden="true"
+        className="absolute top-2 left-2 flex items-center justify-center bg-white rounded p-1 text-gray-700 shadow-shadow1"
+      >
+        <IconExternalLink size={20} />
+      </span>
+    </a>
+  ) : (
+    imgWithTooltip
+  );
+
+  if (!display) return imgWithLink;
+
+  return (
+    <figure>
+      {imgWithLink}
+      <figcaption className="mt-2 text-center text-text-primary">{display}</figcaption>
+    </figure>
+  );
+};
+
+Image.propTypes = {
+  alt: PropTypes.string,
+  source: PropTypes.string,
+  display: PropTypes.string,
+  target: PropTypes.string,
+};
+
+export const ImageLink = (props) => <Image {...props} />;
+
+export const ImageDisplay = (props) => <Image {...props} />;
+
+export const ImageDisplayLink = (props) => <Image {...props} />;
+
+export default Image;

--- a/src/pages/home/useSeeMarkParse.js
+++ b/src/pages/home/useSeeMarkParse.js
@@ -8,6 +8,11 @@ import {
   ExternalLinkTabTitle,
   ExternalLinkTitle,
 } from '@/components/parser-components/external-link/external-link';
+import Image, {
+  ImageDisplay,
+  ImageDisplayLink,
+  ImageLink,
+} from '@/components/parser-components/image/image';
 import InternalLink from '@/components/parser-components/internal-link/internal-link';
 
 const useSeeMarkParse = ({ latexDelimiter, documentFormat, imageFiles }) => {
@@ -26,6 +31,10 @@ const useSeeMarkParse = ({ latexDelimiter, documentFormat, imageFiles }) => {
           externalLinkTab: ExternalLinkTab,
           externalLinkTitle: ExternalLinkTitle,
           externalLinkTabTitle: ExternalLinkTabTitle,
+          image: Image,
+          imageLink: ImageLink,
+          imageDisplay: ImageDisplay,
+          imageDisplayLink: ImageDisplayLink,
         },
       })(markdown);
     },


### PR DESCRIPTION
Solve #119 

- 新增 Image, ImageLink, ImageDisplay, ImageDisplayLink 四個 parser-component，對應 SeeMark 的 4 種圖片語法
```
![image](https://miro.medium.com/v2/resize:fit:770/1*yirDmI8IO62J9ltmE-ovHQ.png)
![imageLink](https://miro.medium.com/v2/resize:fit:770/1*yirDmI8IO62J9ltmE-ovHQ.png)((https://a11yvillage.coseeing.org/zh-TW))
![imageDisplay][[科技新知村報]](https://miro.medium.com/v2/resize:fit:770/1*yirDmI8IO62J9ltmE-ovHQ.png)
![imageDisplayLink][[科技新知村報]](https://miro.medium.com/v2/resize:fit:770/1*yirDmI8IO62J9ltmE-ovHQ.png)((https://a11yvillage.coseeing.org/zh-TW))
```
- Tooltip 使用[現有Tooltip元件](https://github.com/coseeing/Access8MathWeb/blob/main/src/components/core/tooltip.js)製作並[按照Figma圖稿](https://www.figma.com/design/7gvWa3UzE4w5Kloy2CYGTb/%E5%B7%A5%E5%85%B7%E9%A1%9E%E8%A8%AD%E8%A8%88%E7%B3%BB%E7%B5%B1_2025?node-id=906-2956&t=LDRhHR9Um4ItB4fR-0)設置距離圖片16px位置

![結果展示](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzFxdDFsOW8zZmg1eWlvbmw4YXAxYXU5aWhsd3VjeHJpeHUxYzVycSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/L7wsNxo7aazCOInfc0/giphy.gif)