### PR TITLE
fix: group radio inputs with fieldset and legend

### DIFF
--- a/src/components/core/radio-group.js
+++ b/src/components/core/radio-group.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
-const RadioGroup = ({ name, label, options, value, onChange }) => {
+const RadioGroup = ({ name, legend, options, value, onChange }) => {
   return (
-    <div className="flex flex-col gap-2">
-      {label && <span className="text-text-primary text-base">{label}</span>}
+    <fieldset>
+      <legend className="text-text-primary text-base mb-2">{legend}</legend>
       <div className="flex items-center">
         {options.map((option) => (
           <div key={option.value} className="flex flex-1 items-center">
@@ -39,13 +39,13 @@ const RadioGroup = ({ name, label, options, value, onChange }) => {
           </div>
         ))}
       </div>
-    </div>
+    </fieldset>
   );
 };
 
 RadioGroup.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string,
+  legend: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.string.isRequired,

--- a/src/components/link-input-modal.js
+++ b/src/components/link-input-modal.js
@@ -91,7 +91,7 @@ const LinkInputModal = ({ isOpen, onClose, onConfirm }) => {
         />
         <RadioGroup
           name="link-open-method"
-          label={t('openMethod')}
+          legend={t('openMethod')}
           options={[
             { value: 'new-tab', label: t('newTab') },
             { value: 'current-tab', label: t('currentTab') },


### PR DESCRIPTION
## Summary
  - Replaced the `<div>` + `<span>` wrapper in `RadioGroup` with `<fieldset>` + `<legend>` so screen readers announce the group name with each radio option.
  - Renamed the `label` prop to `legend` to match the underlying element, and made it required — every radio group should have an accessible group name.
  - Updated the `LinkInputModal` call site to use the new prop name.