### PR TITLE
fix: invalid prop `children` of type `array` supplied to `BasicModal` warning

### DIFF
--- a/src/components/core/modal/basic-modal.js
+++ b/src/components/core/modal/basic-modal.js
@@ -67,7 +67,7 @@ BasicModal.propTypes = {
   onConfirm: PropTypes.func,
   confirmLabel: PropTypes.string,
   title: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
   hasCancel: PropTypes.bool,
   hasConfirm: PropTypes.bool,
   size: PropTypes.oneOf(['sm', 'l']),


### PR DESCRIPTION
Fix below warning in console:

```
installHook.js:1 Warning: Failed prop type: Invalid prop `children` of type `array` supplied to `BasicModal`, expected a single ReactElement. Error Component Stack
    at BasicModal (basic-modal.js:9:1)
    at TipModal (tip-modal.js:7:1)
    at header (<anonymous>)
    at Header (index.js:12:1)
    at Home (home.js:41:1)
    at RenderedRoute (hooks.tsx:658:1)
    at Outlet (components.tsx:341:1)
    at LocaleContextProvider (locale-switch.js:10:1)
    at Layout (<anonymous>)
    at RenderedRoute (hooks.tsx:658:1)
    at Routes (components.tsx:512:1)
    at Router (components.tsx:421:1)
    at BrowserRouter (index.tsx:789:1)
    at Router (<anonymous>)
```