### PR TITLE
feat: improve responsive layout

### DIFF
--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -14,7 +14,7 @@ const Header = ({ onImportClick, onExportClick, title, onTitleChange }) => {
   const [showTipModal, setShowTipModal] = useState(false);
 
   return (
-    <header className="px-6 fixed h-[72px] flex items-center gap-2 bg-white inset-x-0 z-10 shadow-shadow2">
+    <header className="px-6 sticky top-0 min-w-[768px] h-[72px] flex items-center gap-2 bg-white z-10 shadow-shadow2">
       <div className="flex items-center gap-3 grow">
         <h1 className="sr-only">Access8Math</h1>
         <A8mLogo aria-hidden="true" />
@@ -31,7 +31,7 @@ const Header = ({ onImportClick, onExportClick, title, onTitleChange }) => {
       <div className="flex items-center gap-3">
         <Button
           variant="tertiary"
-          className="min-w-[88px] flex items-center gap-1"
+          className="min-w-[64px] lg:min-w-[88px] flex items-center gap-1"
           onClick={() => setShowTipModal(true)}
         >
           <IconBulb size={16} aria-hidden="true" />
@@ -39,10 +39,14 @@ const Header = ({ onImportClick, onExportClick, title, onTitleChange }) => {
         </Button>
         <Menu />
         <LanguageMenu />
-        <Button variant="secondary" className="min-w-[88px]" onClick={onImportClick}>
+        <Button
+          variant="secondary"
+          className="min-w-[64px] lg:min-w-[88px]"
+          onClick={onImportClick}
+        >
           {t('import')}
         </Button>
-        <Button variant="primary" className="min-w-[88px]" onClick={onExportClick}>
+        <Button variant="primary" className="min-w-[64px] lg:min-w-[88px]" onClick={onExportClick}>
           {t('export')}
         </Button>
       </div>

--- a/src/components/header/language-menu.js
+++ b/src/components/header/language-menu.js
@@ -25,7 +25,11 @@ const LanguageMenu = () => {
   return (
     <DropdownMenu
       triggerButton={
-        <Button variant="tertiary" className="min-w-[88px]" aria-label={t('changeLocale')}>
+        <Button
+          variant="tertiary"
+          className="min-w-[64px] lg:min-w-[88px]"
+          aria-label={t('changeLocale')}
+        >
           <IconLanguage size={16} className="flex-none mr-1" aria-hidden="true" />
           <span>{t(`locale.${i18n.language}`)}</span>
         </Button>

--- a/src/components/header/menu.js
+++ b/src/components/header/menu.js
@@ -64,7 +64,7 @@ const NativeMenu = () => {
   return (
     <DropdownMenu
       triggerButton={
-        <Button variant="tertiary" className="min-w-[88px]" aria-label={t('more')}>
+        <Button variant="tertiary" className="min-w-[64px] lg:min-w-[88px]" aria-label={t('more')}>
           <IconDots size={16} className="flex-none mr-1" aria-hidden="true" />
           <span>{t('more')}</span>
         </Button>

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -322,7 +322,7 @@ export default function Home() {
         title={displayConfig.title}
         onTitleChange={(title) => setDisplayConfig({ title })}
       />
-      <main className="pt-[72px] min-w-[1024px] flex flex-col lg:flex-row">
+      <main className="pt-[72px] min-w-[768px] flex flex-col lg:flex-row">
         {/* Left side input panel */}
         <div className="lg:w-3/5 bg-blue-50 p-6">
           <div className="flex items-center justify-between mb-4">

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -322,7 +322,7 @@ export default function Home() {
         title={displayConfig.title}
         onTitleChange={(title) => setDisplayConfig({ title })}
       />
-      <main className="pt-[72px] min-w-[768px] flex flex-col lg:flex-row">
+      <main className="min-w-[768px] flex flex-col lg:flex-row">
         {/* Left side input panel */}
         <div className="lg:w-3/5 bg-blue-50 p-6">
           <div className="flex items-center justify-between mb-4">
@@ -336,7 +336,7 @@ export default function Home() {
                   items={latexDelimiterOptions}
                   value={displayConfig.latexDelimiter}
                   onChange={(option) => setDisplayConfig({ latexDelimiter: option })}
-                  buttonClassName="w-[88px] h-7"
+                  buttonClassName="w-[64px] h-7"
                 />
               </div>
               <Button variant="secondary" onClick={insertMark}>

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -322,9 +322,9 @@ export default function Home() {
         title={displayConfig.title}
         onTitleChange={(title) => setDisplayConfig({ title })}
       />
-      <main className="pt-[72px] flex flex-col md:flex-row overflow-x-hidden overflow-y-auto">
+      <main className="pt-[72px] min-w-[1024px] flex flex-col lg:flex-row">
         {/* Left side input panel */}
-        <div className="md:w-3/5 bg-blue-50 p-6">
+        <div className="lg:w-3/5 bg-blue-50 p-6">
           <div className="flex items-center justify-between mb-4">
             <h2>{t('editContent')}</h2>
             <div className="flex items-center gap-2">
@@ -378,7 +378,7 @@ export default function Home() {
         </div>
 
         {/* Right side output panel */}
-        <div className="md:w-2/5 flex flex-col md:h-full h-[600px] p-6">
+        <div className="lg:w-2/5 flex flex-col lg:h-full h-[600px] p-6">
           <div className="flex justify-between items-center mb-4">
             <h2>{t('preview')}</h2>
             <div>


### PR DESCRIPTION
## Summary
- Raise the side-by-side breakpoint from 768px (md) to 1024px (lg) so the editor and preview each have enough horizontal room before sharing a row. Below 1024px, the preview stacks full-width beneath the editor.
- Enforce a 768px minimum content width across header and main. Below a 768px viewport, the page scrolls horizontally as one unit instead of compressing the layout.
- Tighten header and toolbar button widths at smaller breakpoints so all controls fit on one row without breaking Chinese labels mid-character.

## Demo

Before

https://github.com/user-attachments/assets/8d43b29d-2476-47aa-ab74-d530f1972ed6

After

https://github.com/user-attachments/assets/36e368a7-9e0d-4713-9b95-5ecc8c3ac8fb

