### PR TITLE
fix: table scroll, link focus, and remove tooltips

### DIFF
--- a/src/components/parser-components/external-link/external-link.js
+++ b/src/components/parser-components/external-link/external-link.js
@@ -2,24 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { IconExternalLink } from '@tabler/icons-react';
 
-import Tooltip from '@/components/core/tooltip';
-
 const linkClassName =
   'inline-flex items-center text-primary underline rounded-sm hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary';
 
-const ExternalLink = ({ display = '', target = '', title = '', newTab = false }) => {
-  const anchor = (
-    <a
-      href={target}
-      {...(newTab && { target: '_blank', rel: 'noopener noreferrer' })}
-      className={linkClassName}
-    >
-      {display}
-      {newTab && <IconExternalLink size={20} aria-hidden="true" />}
-    </a>
-  );
-  return title ? <Tooltip label={title}>{anchor}</Tooltip> : anchor;
-};
+const ExternalLink = ({ display = '', target = '', title = '', newTab = false }) => (
+  <a
+    href={target}
+    {...(title && { title })}
+    {...(newTab && { target: '_blank', rel: 'noopener noreferrer' })}
+    className={linkClassName}
+  >
+    {display}
+    {newTab && <IconExternalLink size={20} aria-hidden="true" />}
+  </a>
+);
 
 ExternalLink.propTypes = {
   display: PropTypes.string,

--- a/src/components/parser-components/external-link/external-link.js
+++ b/src/components/parser-components/external-link/external-link.js
@@ -5,7 +5,7 @@ import { IconExternalLink } from '@tabler/icons-react';
 import Tooltip from '@/components/core/tooltip';
 
 const linkClassName =
-  'inline-flex items-center gap-1 px-2 py-1 rounded text-primary underline hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary';
+  'inline-flex items-center text-primary underline rounded-sm hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary';
 
 const ExternalLink = ({ display = '', target = '', title = '', newTab = false }) => {
   const anchor = (

--- a/src/components/parser-components/image/image.js
+++ b/src/components/parser-components/image/image.js
@@ -2,8 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { IconExternalLink } from '@tabler/icons-react';
 
-import Tooltip from '@/components/core/tooltip';
-
 const useImageBroken = (source) => {
   const [erroredSource, setErroredSource] = useState(null);
   return {
@@ -44,23 +42,6 @@ LinkedImg.propTypes = {
   onError: PropTypes.func,
 };
 
-const AltTooltip = ({ alt = '', disabled = false, children }) => {
-  if (!alt || disabled) return children;
-  return (
-    <span className="block overflow-hidden">
-      <Tooltip label={alt}>
-        <span className="block -mt-[15px] pt-[15px]">{children}</span>
-      </Tooltip>
-    </span>
-  );
-};
-
-AltTooltip.propTypes = {
-  alt: PropTypes.string,
-  disabled: PropTypes.bool,
-  children: PropTypes.node.isRequired,
-};
-
 const Caption = ({ display = '', children }) => (
   <figure>
     {children}
@@ -74,12 +55,8 @@ Caption.propTypes = {
 };
 
 const Image = ({ alt = '', source = '' }) => {
-  const { broken, onError } = useImageBroken(source);
-  return (
-    <AltTooltip alt={alt} disabled={broken}>
-      <Img source={source} alt={alt} onError={onError} />
-    </AltTooltip>
-  );
+  const { onError } = useImageBroken(source);
+  return <Img source={source} alt={alt} onError={onError} />;
 };
 
 Image.propTypes = {
@@ -89,11 +66,7 @@ Image.propTypes = {
 
 export const ImageLink = ({ alt = '', source = '', target = '' }) => {
   const { broken, onError } = useImageBroken(source);
-  return (
-    <AltTooltip alt={alt} disabled={broken}>
-      <LinkedImg source={source} alt={alt} target={target} broken={broken} onError={onError} />
-    </AltTooltip>
-  );
+  return <LinkedImg source={source} alt={alt} target={target} broken={broken} onError={onError} />;
 };
 
 ImageLink.propTypes = {
@@ -103,12 +76,10 @@ ImageLink.propTypes = {
 };
 
 export const ImageDisplay = ({ alt = '', display = '', source = '' }) => {
-  const { broken, onError } = useImageBroken(source);
+  const { onError } = useImageBroken(source);
   return (
     <Caption display={display}>
-      <AltTooltip alt={alt} disabled={broken}>
-        <Img source={source} alt={alt} onError={onError} />
-      </AltTooltip>
+      <Img source={source} alt={alt} onError={onError} />
     </Caption>
   );
 };
@@ -123,9 +94,7 @@ export const ImageDisplayLink = ({ alt = '', display = '', source = '', target =
   const { broken, onError } = useImageBroken(source);
   return (
     <Caption display={display}>
-      <AltTooltip alt={alt} disabled={broken}>
-        <LinkedImg source={source} alt={alt} target={target} broken={broken} onError={onError} />
-      </AltTooltip>
+      <LinkedImg source={source} alt={alt} target={target} broken={broken} onError={onError} />
     </Caption>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -106,5 +106,5 @@ math {
 }
 
 .right-side-preview-area a:not([class]) {
-  @apply inline-flex items-center gap-1 px-2 py-1 rounded text-primary underline hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary;
+  @apply inline-flex items-center text-primary underline rounded-sm hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -62,6 +62,13 @@ math {
   padding-left: 1.5em;
 }
 
+.right-side-preview-area table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .right-side-preview-area table td,
 .right-side-preview-area table th {
   padding: 8px;


### PR DESCRIPTION
### Changes

1. https://github.com/coseeing/Access8MathWeb/pull/139/changes/6fe6997f95efdcb3028d566f3ba5f4f07cabdf44 讓右側預覽區域內過寬的表格可以橫向捲動，避免內容溢出容器導致看不到被截斷的欄位。
2. https://github.com/coseeing/Access8MathWeb/pull/139/changes/8396087e8fd55e74596b441a73f67161081b113a 調整連結樣式：讓鍵盤聚焦時的 focus ring 緊貼連結文字本身，視覺上更貼合。
3. https://github.com/coseeing/Access8MathWeb/pull/139/changes/a583d98153929d17a0234b646898dbd86c38383b 按照昨日會議討論，暫時移除 ExternalLink、Image、ImageLink、ImageDisplay、ImageDisplayLink 上的自訂 Tooltip。待日後與設計師共同優化後，再加回。

### Demo

Table:

| Before (會破版) | After (可左右捲動) |
| ------ | ----- |
| <img width="1846" height="996" alt="Screenshot 2026-05-20 at 16 44 55" src="https://github.com/user-attachments/assets/01217979-6411-43fe-a615-0c6e15394199" /> | <img width="1846" height="996" alt="Screenshot 2026-05-20 at 16 51 37" src="https://github.com/user-attachments/assets/438be259-c6b0-49d3-b663-7e27706beb9c" /> |

Link focus:

| Before | After |
| ------ | ----- |
| <img width="1846" height="996" alt="Screenshot 2026-05-20 at 16 48 20" src="https://github.com/user-attachments/assets/8ae417b0-7edb-4f7e-aff9-8cfed3e52a32" /> | <img width="1846" height="996" alt="Screenshot 2026-05-20 at 16 47 38" src="https://github.com/user-attachments/assets/91a9b009-a127-4d99-869d-0ad88b5f29e4" /> |