### PR TITLE
chore: bump CI actions to Node 24 runtime

### DIFF
--- a/.github/workflows/create-bump-package-version.yml
+++ b/.github/workflows/create-bump-package-version.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Authenticate with github package registry
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc

--- a/.github/workflows/staging-build-and-deploy.yml
+++ b/.github/workflows/staging-build-and-deploy.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Authenticate with github package registry
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc

--- a/.github/workflows/web-production-publish.yml
+++ b/.github/workflows/web-production-publish.yml
@@ -19,7 +19,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Authenticate with github package registry
         run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc

--- a/.github/workflows/windows-production-publish.yml
+++ b/.github/workflows/windows-production-publish.yml
@@ -16,7 +16,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get package version
         id: package-version
@@ -27,7 +27,7 @@ jobs:
           echo "version=$version" >> $env:GITHUB_OUTPUT
 
       - name: Setup NodeJS env
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20.x'
 
@@ -46,7 +46,7 @@ jobs:
           ls "./out/make/squirrel.windows/x64/access-8-math-web-${{steps.package-version.outputs.version}} Setup.exe"
 
       - name: Upload Installer
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: './out/make/squirrel.windows/x64/access-8-math-web-${{steps.package-version.outputs.version}} Setup.exe'


### PR DESCRIPTION
Address warning from GitHub: https://github.com/coseeing/Access8MathWeb/actions/runs/26554834723

<img width="1400" height="338" alt="Screenshot 2026-06-03 at 15 34 35" src="https://github.com/user-attachments/assets/047f05aa-babe-44b3-b226-ae6269338b17" />
