### PR TITLE
fix: correct dark mode colors for figcaption and links in preview panel

### DIFF
--- a/src/components/parser-components/external-link/external-link.js
+++ b/src/components/parser-components/external-link/external-link.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { IconExternalLink } from '@tabler/icons-react';
 
 const linkClassName =
-  'inline-flex items-center text-primary underline rounded-sm hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary';
+  'inline-flex items-center text-primary underline rounded-sm hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary [.darkmode_&]:text-blue-200 [.darkmode_&]:hover:text-blue-500 [.darkmode_&]:focus-visible:outline-blue-200';
 
 const ExternalLink = ({ display = '', target = '', title = '', newTab = false }) => (
   <a

--- a/src/index.css
+++ b/src/index.css
@@ -101,7 +101,8 @@ math {
 .right-side-preview-area.darkmode h3,
 .right-side-preview-area.darkmode h4,
 .right-side-preview-area.darkmode h5,
-.right-side-preview-area.darkmode h6 {
+.right-side-preview-area.darkmode h6,
+.right-side-preview-area.darkmode figcaption {
   color: white;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -109,3 +109,7 @@ math {
 .right-side-preview-area a:not([class]) {
   @apply inline-flex items-center text-primary underline rounded-sm hover:text-blue-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary;
 }
+
+.right-side-preview-area.darkmode a:not([class]) {
+  @apply text-blue-200 hover:text-blue-500 focus-visible:outline-blue-200;
+}


### PR DESCRIPTION
## Goal

修復設計師回報的顏色問題。
https://docs.google.com/document/d/1o80SD1jfOYbKEKcX0WodZ-PL8xgvA8Xii2GAVOXJzYc/edit?tab=t.0

1. 在打開黑底白字的情況下，圖片說明（figcaption）文字顏色錯誤
2. 在打開黑底白字的情框下，連結文字與焦點外框的顏色錯誤

## Demo

### figcaption (before)

<img width="684" height="536" alt="Screenshot 2026-06-22 at 09 56 39" src="https://github.com/user-attachments/assets/6da82afe-f71f-400d-a4f9-f722c8546459" />

### figcaption (after)

<img width="577" height="460" alt="Screenshot 2026-06-22 at 09 58 12" src="https://github.com/user-attachments/assets/ef11c7fd-a6b2-401f-84ba-4a3ec46323bb" />

### link (before)

<img width="276" height="295" alt="Screenshot 2026-06-22 at 09 57 03" src="https://github.com/user-attachments/assets/0736b999-94e9-49ee-b9bf-54df54e3ea7b" />

## link (after)

<img width="295" height="288" alt="Screenshot 2026-06-22 at 09 56 54" src="https://github.com/user-attachments/assets/15d6a55a-b1a5-4f57-af15-ec934bb3f594" />

## ToDos

- [ ] 改用 tailwind 管理 preview panel 的 light/dark mode
