### PR TITLE
feat: iframe/youtube/codepen apply 16:9 sizing in preview panel

### DIFF
--- a/src/components/parser-components/codepen/codepen.js
+++ b/src/components/parser-components/codepen/codepen.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// adapted from CodePen official embed
+const CodePen = ({ title = '', source = '' }) => (
+  <iframe
+    src={source}
+    title={title}
+    scrolling="no"
+    frameBorder="no"
+    loading="lazy"
+    // eslint-disable-next-line react/no-unknown-property
+    allowTransparency="true"
+    className="block w-full aspect-video border-0"
+  />
+);
+
+CodePen.propTypes = {
+  title: PropTypes.string,
+  source: PropTypes.string,
+};
+
+export default CodePen;

--- a/src/components/parser-components/iframe/iframe.js
+++ b/src/components/parser-components/iframe/iframe.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Iframe = ({ title = '', source = '' }) => (
+  <iframe title={title} src={source} className="block w-full aspect-video border-0" />
+);
+
+Iframe.propTypes = {
+  title: PropTypes.string,
+  source: PropTypes.string,
+};
+
+export default Iframe;

--- a/src/components/parser-components/youtube/youtube.js
+++ b/src/components/parser-components/youtube/youtube.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// adapted from YouTube official embed
+const YouTube = ({ title = '', source = '' }) => (
+  <iframe
+    src={source}
+    title={title}
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerPolicy="strict-origin-when-cross-origin"
+    allowFullScreen
+    className="block w-full aspect-video border-0"
+  />
+);
+
+YouTube.propTypes = {
+  title: PropTypes.string,
+  source: PropTypes.string,
+};
+
+export default YouTube;

--- a/src/pages/home/useSeeMarkParse.js
+++ b/src/pages/home/useSeeMarkParse.js
@@ -14,6 +14,9 @@ import Image, {
   ImageLink,
 } from '@/components/parser-components/image/image';
 import InternalLink from '@/components/parser-components/internal-link/internal-link';
+import Iframe from '@/components/parser-components/iframe/iframe';
+import YouTube from '@/components/parser-components/youtube/youtube';
+import CodePen from '@/components/parser-components/codepen/codepen';
 
 const useSeeMarkParse = ({ latexDelimiter, documentFormat, imageFiles }) => {
   const seeMarkReactParse = useCallback(
@@ -35,6 +38,9 @@ const useSeeMarkParse = ({ latexDelimiter, documentFormat, imageFiles }) => {
           imageLink: ImageLink,
           imageDisplay: ImageDisplay,
           imageDisplayLink: ImageDisplayLink,
+          iframe: Iframe,
+          youtube: YouTube,
+          codepen: CodePen,
         },
       })(markdown);
     },


### PR DESCRIPTION
## Goal
設計師希望 iframe 類型內容，在 preview panel 內顯示時，可以維持寬高 16:9（aka Tailwind `aspect-video`）的比例，且寬不超過整個 preview 區域。

討論：
https://docs.google.com/document/d/1o80SD1jfOYbKEKcX0WodZ-PL8xgvA8Xii2GAVOXJzYc/edit?tab=t.0#heading=h.65w61zh43oa0
https://coseeing.slack.com/archives/C0AABUFUQ01/p1780557641609349?thread_ts=1779198395.123149&cid=C0AABUFUQ01


## Before
寬高固定，因此 preview 區域太小時會破版

<img width="1853" height="994" alt="Screenshot 2026-06-22 at 10 58 47" src="https://github.com/user-attachments/assets/14bc9f15-cf83-44ff-ac38-401620d9098a" />

## After 
<img width="1853" height="994" alt="Screenshot 2026-06-22 at 10 57 45" src="https://github.com/user-attachments/assets/7c56c8e1-e520-4392-93fb-e5ae810058c7" />
