### PR TITLE
refactor: use tailwind spacing scale utilities instead of arbitrary px values

### DIFF
--- a/src/components/core/toast/toast.js
+++ b/src/components/core/toast/toast.js
@@ -100,7 +100,7 @@ const Toast = ({ toast, onRemove, onRemoveStart }) => {
         key={id}
         role="status"
         aria-live="polite"
-        className={`min-h-8 w-80 pl-4 pr-2 py-[6px] flex items-center gap-1 text-sm mb-2 rounded-lg ${toastTypeClasses[type]}`}
+        className={`min-h-8 w-80 pl-4 pr-2 py-1.5 flex items-center gap-1 text-sm mb-2 rounded-lg ${toastTypeClasses[type]}`}
         onMouseEnter={handlePause}
         onMouseLeave={handleResume}
       >

--- a/src/components/core/tooltip.js
+++ b/src/components/core/tooltip.js
@@ -90,12 +90,12 @@ const Tooltip = ({ children, label, position = 'top' }) => {
   });
 
   const arrowClass = {
-    top: 'absolute left-1/2 -translate-x-1/2 -bottom-[14px] border-[7px] border-transparent border-t-[#1A1A1A99]',
+    top: 'absolute left-1/2 -translate-x-1/2 -bottom-3.5 border-[7px] border-transparent border-t-[#1A1A1A99]',
     bottom:
-      'absolute left-1/2 -translate-x-1/2 -top-[14px] border-[7px] border-transparent border-b-[#1A1A1A99]',
-    left: 'absolute top-1/2 -translate-y-1/2 -right-[14px] border-[7px] border-transparent border-l-[#1A1A1A99]',
+      'absolute left-1/2 -translate-x-1/2 -top-3.5 border-[7px] border-transparent border-b-[#1A1A1A99]',
+    left: 'absolute top-1/2 -translate-y-1/2 -right-3.5 border-[7px] border-transparent border-l-[#1A1A1A99]',
     right:
-      'absolute top-1/2 -translate-y-1/2 -left-[14px] border-[7px] border-transparent border-r-[#1A1A1A99]',
+      'absolute top-1/2 -translate-y-1/2 -left-3.5 border-[7px] border-transparent border-r-[#1A1A1A99]',
   };
 
   return (

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -31,7 +31,7 @@ const Header = ({ onImportClick, onExportClick, title, onTitleChange }) => {
       <div className="flex items-center gap-3">
         <Button
           variant="tertiary"
-          className="min-w-[64px] lg:min-w-[88px] flex items-center gap-1"
+          className="min-w-16 lg:min-w-[88px] flex items-center gap-1"
           onClick={() => setShowTipModal(true)}
         >
           <IconBulb size={16} aria-hidden="true" />
@@ -39,14 +39,10 @@ const Header = ({ onImportClick, onExportClick, title, onTitleChange }) => {
         </Button>
         <Menu />
         <LanguageMenu />
-        <Button
-          variant="secondary"
-          className="min-w-[64px] lg:min-w-[88px]"
-          onClick={onImportClick}
-        >
+        <Button variant="secondary" className="min-w-16 lg:min-w-[88px]" onClick={onImportClick}>
           {t('import')}
         </Button>
-        <Button variant="primary" className="min-w-[64px] lg:min-w-[88px]" onClick={onExportClick}>
+        <Button variant="primary" className="min-w-16 lg:min-w-[88px]" onClick={onExportClick}>
           {t('export')}
         </Button>
       </div>

--- a/src/components/header/language-menu.js
+++ b/src/components/header/language-menu.js
@@ -27,7 +27,7 @@ const LanguageMenu = () => {
       triggerButton={
         <Button
           variant="tertiary"
-          className="min-w-[64px] lg:min-w-[88px]"
+          className="min-w-16 lg:min-w-[88px]"
           aria-label={t('changeLocale')}
         >
           <IconLanguage size={16} className="flex-none mr-1" aria-hidden="true" />

--- a/src/components/header/menu.js
+++ b/src/components/header/menu.js
@@ -64,7 +64,7 @@ const NativeMenu = () => {
   return (
     <DropdownMenu
       triggerButton={
-        <Button variant="tertiary" className="min-w-[64px] lg:min-w-[88px]" aria-label={t('more')}>
+        <Button variant="tertiary" className="min-w-16 lg:min-w-[88px]" aria-label={t('more')}>
           <IconDots size={16} className="flex-none mr-1" aria-hidden="true" />
           <span>{t('more')}</span>
         </Button>

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -340,7 +340,7 @@ export default function Home() {
                   items={latexDelimiterOptions}
                   value={displayConfig.latexDelimiter}
                   onChange={(option) => setDisplayConfig({ latexDelimiter: option })}
-                  buttonClassName="w-[64px] h-7"
+                  buttonClassName="w-16 h-7"
                 />
               </div>
               <Button variant="secondary" onClick={insertMark}>


### PR DESCRIPTION
把 6 處數值剛好落在 Tailwind 預設 spacing scale 上的 arbitrary value，換成對應的 utility class：

- min-w-[64px] → min-w-16  (header 的 tip / import / export / more / language 按鈕)
- w-[64px]     → w-16      (home 的 LaTeX delimiter segmented control)
- py-[6px]     → py-1.5    (toast)
- -{bottom,top,right,left}-[14px] → -3.5  (tooltip 箭頭)

單位隨之由 px 變成 rem（4rem / 0.375rem / -0.875rem）。在預設 16px root font-size 下數值等價，且使用者調大瀏覽器預設字級時會跟著縮放，對按鈕最小寬度與 toast padding 來說是應是預期的行為。

其餘 arbitrary value 保留：min-w-[88px] / h-[72px] / max-w-[280px] / h-[600px] / min-w-[768px] 雖是 4 的倍數，但對應的 class 要 Tailwind 4 的 dynamic spacing scale 才存在；按鈕的 px-[11px] / py-[7px] 等是刻意的 border 補償。